### PR TITLE
Change Get/Set WindowLong (W) ->  Get/Set WindowLongPtr (W) for 64 bi…

### DIFF
--- a/platforms/win32/plugins/B3DAcceleratorPlugin/sqWin32OpenGL.c
+++ b/platforms/win32/plugins/B3DAcceleratorPlugin/sqWin32OpenGL.c
@@ -143,7 +143,7 @@ static HWND glCreateClientWindow(HWND parentWindow, int x, int y, int w, int h)
   const char *className = "Squeak-OpenGLWindow";
 
   if(!parentWindow) return NULL;
-  hInstance = (HINSTANCE) GetWindowLong((HWND)parentWindow,GWL_HINSTANCE);
+  hInstance = (HINSTANCE) GetWindowLongPtr((HWND)parentWindow,GWLP_HINSTANCE);
   windowClass.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
   windowClass.lpfnWndProc = glWindowProcedure;
   windowClass.cbClsExtra = 0;

--- a/platforms/win32/plugins/HostWindowPlugin/sqWin32HostWindowPlugin.c
+++ b/platforms/win32/plugins/HostWindowPlugin/sqWin32HostWindowPlugin.c
@@ -184,7 +184,7 @@ sqInt createWindowWidthheightoriginXyattrlength(sqInt w, sqInt h, sqInt x, sqInt
 			NULL);
 
   /* Force Unicode WM_CHAR */
-  SetWindowLongW(hwnd,GWL_WNDPROC,(DWORD)HostWndProcW);
+  SetWindowLongPtrW(hwnd,GWLP_WNDPROC,(DWORD)HostWndProcW);
 
   return (int)hwnd;
 }

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -907,7 +907,7 @@ void SetupWindows()
 			      NULL);
   }
   /* Force Unicode WM_CHAR */
-  SetWindowLongW(stWindow,GWL_WNDPROC,(DWORD)MainWndProcW);
+  SetWindowLongPtrW(stWindow,GWLP_WNDPROC,(DWORD)MainWndProcW);
 
 #ifndef NO_WHEEL_MOUSE
   g_WM_MOUSEWHEEL = RegisterWindowMessage( TEXT("MSWHEEL_ROLLMSG") ); /* RvL 1999-04-19 00:23 */
@@ -1809,8 +1809,8 @@ int ioSetFullScreen(int fullScreen) {
 	/* SetWindowPos(stWindow, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); */
 	browserWindow = oldBrowserWindow;
       }
-      SetWindowLong(stWindow,GWL_STYLE, WS_POPUP | WS_CLIPCHILDREN);
-      SetWindowLong(stWindow,GWL_EXSTYLE, WS_EX_APPWINDOW);
+      SetWindowLongPtr(stWindow,GWLP_STYLE, WS_POPUP | WS_CLIPCHILDREN);
+      SetWindowLongPtr(stWindow,GWLP_EXSTYLE, WS_EX_APPWINDOW);
       ShowWindow(stWindow, SW_SHOWMAXIMIZED);
 #else /* !defined(_WIN32_WCE) */
       ShowWindow(stWindow,SW_SHOWNORMAL);
@@ -1822,8 +1822,8 @@ int ioSetFullScreen(int fullScreen) {
 #if !defined(_WIN32_WCE)
       ShowWindow(stWindow, SW_RESTORE);
       ShowWindow(stWindow, SW_HIDE);
-      SetWindowLong(stWindow,GWL_STYLE, WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN);
-      SetWindowLong(stWindow,GWL_EXSTYLE, WS_EX_APPWINDOW /* | WS_EX_OVERLAPPEDWINDOW */ );
+      SetWindowLongPtr(stWindow,GWLP_STYLE, WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN);
+      SetWindowLongPtr(stWindow,GWLP_EXSTYLE, WS_EX_APPWINDOW /* | WS_EX_OVERLAPPEDWINDOW */ );
       SetWindowPos(stWindow,0,0,0,0,0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED | SWP_NOREDRAW);
       if(browserWindow) {
 	/* Jump back into the browser */
@@ -2063,7 +2063,7 @@ int ioSetDisplayMode(int width, int height, int depth, int fullscreenFlag)
     r.right = GetSystemMetrics(SM_CXSCREEN);
     r.bottom = GetSystemMetrics(SM_CYSCREEN);
   } else {
-    AdjustWindowRect(&r, GetWindowLong(stWindow, GWL_STYLE), 0);
+    AdjustWindowRect(&r, GetWindowLongPtr(stWindow, GWLP_STYLE), 0);
   }
   SetWindowPos(stWindow, NULL, 0, 0, r.right-r.left, r.bottom-r.top,
 	       SWP_NOMOVE | SWP_NOZORDER);

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -1809,8 +1809,8 @@ int ioSetFullScreen(int fullScreen) {
 	/* SetWindowPos(stWindow, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); */
 	browserWindow = oldBrowserWindow;
       }
-      SetWindowLongPtr(stWindow,GWLP_STYLE, WS_POPUP | WS_CLIPCHILDREN);
-      SetWindowLongPtr(stWindow,GWLP_EXSTYLE, WS_EX_APPWINDOW);
+      SetWindowLongPtr(stWindow,GWL_STYLE, WS_POPUP | WS_CLIPCHILDREN);
+      SetWindowLongPtr(stWindow,GWL_EXSTYLE, WS_EX_APPWINDOW);
       ShowWindow(stWindow, SW_SHOWMAXIMIZED);
 #else /* !defined(_WIN32_WCE) */
       ShowWindow(stWindow,SW_SHOWNORMAL);
@@ -1822,8 +1822,8 @@ int ioSetFullScreen(int fullScreen) {
 #if !defined(_WIN32_WCE)
       ShowWindow(stWindow, SW_RESTORE);
       ShowWindow(stWindow, SW_HIDE);
-      SetWindowLongPtr(stWindow,GWLP_STYLE, WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN);
-      SetWindowLongPtr(stWindow,GWLP_EXSTYLE, WS_EX_APPWINDOW /* | WS_EX_OVERLAPPEDWINDOW */ );
+      SetWindowLongPtr(stWindow,GWL_STYLE, WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN);
+      SetWindowLongPtr(stWindow,GWL_EXSTYLE, WS_EX_APPWINDOW /* | WS_EX_OVERLAPPEDWINDOW */ );
       SetWindowPos(stWindow,0,0,0,0,0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED | SWP_NOREDRAW);
       if(browserWindow) {
 	/* Jump back into the browser */
@@ -2063,7 +2063,7 @@ int ioSetDisplayMode(int width, int height, int depth, int fullscreenFlag)
     r.right = GetSystemMetrics(SM_CXSCREEN);
     r.bottom = GetSystemMetrics(SM_CYSCREEN);
   } else {
-    AdjustWindowRect(&r, GetWindowLongPtr(stWindow, GWLP_STYLE), 0);
+    AdjustWindowRect(&r, GetWindowLongPtr(stWindow, GWL_STYLE), 0);
   }
   SetWindowPos(stWindow, NULL, 0, 0, r.right-r.left, r.bottom-r.top,
 	       SWP_NOMOVE | SWP_NOZORDER);


### PR DESCRIPTION
GetWindowLong and SetWindowLong(W) are 32 bits only.
For compatibility with 64 bits, one must use GetWindowLongPtr SetWindowLongPtr(W).

See Microsoft documentation i.e. https://msdn.microsoft.com/en-us/library/windows/desktop/ms633584%28v=vs.85%29.aspx

Notice: I did not compile the code, win32 compilation setup being quite obsolete
but it's a good occasion to test social pull request and automated builds :)