### PR TITLE
Set window long ptr 64bit compatibility

### DIFF
--- a/platforms/win32/plugins/B3DAcceleratorPlugin/sqWin32OpenGL.c
+++ b/platforms/win32/plugins/B3DAcceleratorPlugin/sqWin32OpenGL.c
@@ -143,7 +143,7 @@ static HWND glCreateClientWindow(HWND parentWindow, int x, int y, int w, int h)
   const char *className = "Squeak-OpenGLWindow";
 
   if(!parentWindow) return NULL;
-  hInstance = (HINSTANCE) GetWindowLong((HWND)parentWindow,GWL_HINSTANCE);
+  hInstance = (HINSTANCE) GetWindowLongPtr((HWND)parentWindow,GWLP_HINSTANCE);
   windowClass.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
   windowClass.lpfnWndProc = glWindowProcedure;
   windowClass.cbClsExtra = 0;

--- a/platforms/win32/plugins/HostWindowPlugin/sqWin32HostWindowPlugin.c
+++ b/platforms/win32/plugins/HostWindowPlugin/sqWin32HostWindowPlugin.c
@@ -184,7 +184,7 @@ sqInt createWindowWidthheightoriginXyattrlength(sqInt w, sqInt h, sqInt x, sqInt
 			NULL);
 
   /* Force Unicode WM_CHAR */
-  SetWindowLongW(hwnd,GWL_WNDPROC,(DWORD)HostWndProcW);
+  SetWindowLongPtrW(hwnd,GWLP_WNDPROC,(DWORD)HostWndProcW);
 
   return (int)hwnd;
 }

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -907,7 +907,7 @@ void SetupWindows()
 			      NULL);
   }
   /* Force Unicode WM_CHAR */
-  SetWindowLongW(stWindow,GWL_WNDPROC,(DWORD)MainWndProcW);
+  SetWindowLongPtrW(stWindow,GWLP_WNDPROC,(DWORD)MainWndProcW);
 
 #ifndef NO_WHEEL_MOUSE
   g_WM_MOUSEWHEEL = RegisterWindowMessage( TEXT("MSWHEEL_ROLLMSG") ); /* RvL 1999-04-19 00:23 */
@@ -1809,8 +1809,8 @@ int ioSetFullScreen(int fullScreen) {
 	/* SetWindowPos(stWindow, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); */
 	browserWindow = oldBrowserWindow;
       }
-      SetWindowLong(stWindow,GWL_STYLE, WS_POPUP | WS_CLIPCHILDREN);
-      SetWindowLong(stWindow,GWL_EXSTYLE, WS_EX_APPWINDOW);
+      SetWindowLongPtr(stWindow,GWLP_STYLE, WS_POPUP | WS_CLIPCHILDREN);
+      SetWindowLongPtr(stWindow,GWLP_EXSTYLE, WS_EX_APPWINDOW);
       ShowWindow(stWindow, SW_SHOWMAXIMIZED);
 #else /* !defined(_WIN32_WCE) */
       ShowWindow(stWindow,SW_SHOWNORMAL);
@@ -1822,8 +1822,8 @@ int ioSetFullScreen(int fullScreen) {
 #if !defined(_WIN32_WCE)
       ShowWindow(stWindow, SW_RESTORE);
       ShowWindow(stWindow, SW_HIDE);
-      SetWindowLong(stWindow,GWL_STYLE, WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN);
-      SetWindowLong(stWindow,GWL_EXSTYLE, WS_EX_APPWINDOW /* | WS_EX_OVERLAPPEDWINDOW */ );
+      SetWindowLongPtr(stWindow,GWLP_STYLE, WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN);
+      SetWindowLongPtr(stWindow,GWLP_EXSTYLE, WS_EX_APPWINDOW /* | WS_EX_OVERLAPPEDWINDOW */ );
       SetWindowPos(stWindow,0,0,0,0,0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED | SWP_NOREDRAW);
       if(browserWindow) {
 	/* Jump back into the browser */
@@ -2063,7 +2063,7 @@ int ioSetDisplayMode(int width, int height, int depth, int fullscreenFlag)
     r.right = GetSystemMetrics(SM_CXSCREEN);
     r.bottom = GetSystemMetrics(SM_CYSCREEN);
   } else {
-    AdjustWindowRect(&r, GetWindowLong(stWindow, GWL_STYLE), 0);
+    AdjustWindowRect(&r, GetWindowLongPtr(stWindow, GWLP_STYLE), 0);
   }
   SetWindowPos(stWindow, NULL, 0, 0, r.right-r.left, r.bottom-r.top,
 	       SWP_NOMOVE | SWP_NOZORDER);

--- a/platforms/win32/vm/sqWin32Window.c
+++ b/platforms/win32/vm/sqWin32Window.c
@@ -1809,8 +1809,8 @@ int ioSetFullScreen(int fullScreen) {
 	/* SetWindowPos(stWindow, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW); */
 	browserWindow = oldBrowserWindow;
       }
-      SetWindowLongPtr(stWindow,GWLP_STYLE, WS_POPUP | WS_CLIPCHILDREN);
-      SetWindowLongPtr(stWindow,GWLP_EXSTYLE, WS_EX_APPWINDOW);
+      SetWindowLongPtr(stWindow,GWL_STYLE, WS_POPUP | WS_CLIPCHILDREN);
+      SetWindowLongPtr(stWindow,GWL_EXSTYLE, WS_EX_APPWINDOW);
       ShowWindow(stWindow, SW_SHOWMAXIMIZED);
 #else /* !defined(_WIN32_WCE) */
       ShowWindow(stWindow,SW_SHOWNORMAL);
@@ -1822,8 +1822,8 @@ int ioSetFullScreen(int fullScreen) {
 #if !defined(_WIN32_WCE)
       ShowWindow(stWindow, SW_RESTORE);
       ShowWindow(stWindow, SW_HIDE);
-      SetWindowLongPtr(stWindow,GWLP_STYLE, WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN);
-      SetWindowLongPtr(stWindow,GWLP_EXSTYLE, WS_EX_APPWINDOW /* | WS_EX_OVERLAPPEDWINDOW */ );
+      SetWindowLongPtr(stWindow,GWL_STYLE, WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN);
+      SetWindowLongPtr(stWindow,GWL_EXSTYLE, WS_EX_APPWINDOW /* | WS_EX_OVERLAPPEDWINDOW */ );
       SetWindowPos(stWindow,0,0,0,0,0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED | SWP_NOREDRAW);
       if(browserWindow) {
 	/* Jump back into the browser */
@@ -2063,7 +2063,7 @@ int ioSetDisplayMode(int width, int height, int depth, int fullscreenFlag)
     r.right = GetSystemMetrics(SM_CXSCREEN);
     r.bottom = GetSystemMetrics(SM_CYSCREEN);
   } else {
-    AdjustWindowRect(&r, GetWindowLongPtr(stWindow, GWLP_STYLE), 0);
+    AdjustWindowRect(&r, GetWindowLongPtr(stWindow, GWL_STYLE), 0);
   }
   SetWindowPos(stWindow, NULL, 0, 0, r.right-r.left, r.bottom-r.top,
 	       SWP_NOMOVE | SWP_NOZORDER);


### PR DESCRIPTION
The GetWindowLong and SetWindowLong(W) functions work for 32bits pointer only...
Use GetWindowLongPtr instead of GetWindowLong (same for Set) so as to be 64bits compatible.

See Microsoft documentation, i.e. https://msdn.microsoft.com/en-us/library/windows/desktop/ms633585%28v=vs.85%29.aspx

This is is 2nd pull request, with corrected GWL_STYLE and GWL_EXSTYLE which must not be renamed to GWLP_ unlike other constants.
