### PR TITLE
Fix ARM builds for Newspeak.

### DIFF
--- a/build.linux32ARM/newspeak.cog.spur/build.assert/mvm
+++ b/build.linux32ARM/newspeak.cog.spur/build.assert/mvm
@@ -18,11 +18,11 @@ test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -
 test -f config.h || ../../../platforms/unix/config/configure --without-npsqueak \
 		--without-vm-display-fbdev --with-vmversion=5.0 \
 		--with-src=nsspursrc \
-		--without-vm-display-fbdev --without-npsqueak --enable-fast-bitblt \
-	CC="gcc -march=armv6 -mfpu=vfp -mfloat-abi=hard" \
+		--without-vm-display-fbdev --without-npsqueak \
+	CC=gcc \
 	CXX=g++ \
 	CFLAGS="$OPT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -DI_REALLY_DONT_CARE_HOW_UNSAFE_THIS_IS -DCOGMTVM=0" \
-	LIBS="-lpthread -luuid -lasound" \
+	LIBS="-lpthread -luuid" \
 	LDFLAGS=-Wl,-z,now
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR

--- a/build.linux32ARM/newspeak.cog.spur/build.debug/mvm
+++ b/build.linux32ARM/newspeak.cog.spur/build.debug/mvm
@@ -18,11 +18,11 @@ test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -
 test -f config.h || ../../../platforms/unix/config/configure --without-npsqueak \
 		--without-vm-display-fbdev --with-vmversion=5.0 \
 		--with-src=nsspursrc \
-		--without-vm-display-fbdev --without-npsqueak --enable-fast-bitblt \
-	CC="gcc -march=armv6 -mfpu=vfp -mfloat-abi=hard" \
+		--without-vm-display-fbdev --without-npsqueak \
+	CC=gcc \
 	CXX=g++ \
 	CFLAGS="$OPT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64  -DI_REALLY_DONT_CARE_HOW_UNSAFE_THIS_IS -DCOGMTVM=0" \
-	LIBS="-lpthread -luuid -lasound" \
+	LIBS="-lpthread -luuid" \
 	LDFLAGS=-Wl,-z,now
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR

--- a/build.linux32ARM/newspeak.cog.spur/build/mvm
+++ b/build.linux32ARM/newspeak.cog.spur/build/mvm
@@ -18,11 +18,11 @@ test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -
 test -f config.h || ../../../platforms/unix/config/configure --without-npsqueak \
 		--without-vm-display-fbdev --with-vmversion=5.0 \
 		--with-src=nsspursrc \
-		--without-vm-display-fbdev --without-npsqueak --enable-fast-bitblt \
-	CC="gcc -march=armv6 -mfpu=vfp -mfloat-abi=hard" \
+		--without-vm-display-fbdev --without-npsqueak \
+	CC=gcc \
 	CXX=g++ \
 	CFLAGS="$OPT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -DI_REALLY_DONT_CARE_HOW_UNSAFE_THIS_IS -DCOGMTVM=0" \
-	LIBS="-lpthread -luuid -lasound" \
+	LIBS="-lpthread -luuid" \
 	LDFLAGS=-Wl,-z,now
 rm -f vm/sqUnixMain.o # nuke version info
 rm -rf ../../../products/$INSTALLDIR

--- a/build.linux32ARM/newspeak.stack.spur/build.assert/mvm
+++ b/build.linux32ARM/newspeak.stack.spur/build.assert/mvm
@@ -18,8 +18,8 @@ test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -
 test -f config.h || ../../../platforms/unix/config/configure \
 	--with-vmversion=5.0 \
 	--with-src=nsspurstacksrc --disable-cogit \
-	--without-vm-display-fbdev --without-npsqueak --enable-fast-bitblt \
-	CC="gcc -march=armv6 -mfpu=vfp -mfloat-abi=hard" \
+	--without-vm-display-fbdev --without-npsqueak \
+	CC=gcc \
 	CXX=g++ \
 	CFLAGS="$OPT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64" \
 	LIBS="-lpthread -luuid" \

--- a/build.linux32ARM/newspeak.stack.spur/build.debug/mvm
+++ b/build.linux32ARM/newspeak.stack.spur/build.debug/mvm
@@ -18,8 +18,8 @@ test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -
 test -f config.h || ../../../platforms/unix/config/configure \
 	--with-vmversion=5.0 \
 	--with-src=nsspurstacksrc --disable-cogit \
-	--without-vm-display-fbdev --without-npsqueak --enable-fast-bitblt \
-	CC="gcc -march=armv6 -mfpu=vfp -mfloat-abi=hard" \
+	--without-vm-display-fbdev --without-npsqueak \
+	CC=gcc \
 	CXX=g++ \
 	CFLAGS="$OPT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64" \
 	LIBS="-lpthread -luuid" \

--- a/build.linux32ARM/newspeak.stack.spur/build/mvm
+++ b/build.linux32ARM/newspeak.stack.spur/build/mvm
@@ -18,8 +18,8 @@ test -f plugins.ext || (test -f ../plugins.ext && cp -p ../plugins.ext . || cp -
 test -f config.h || ../../../platforms/unix/config/configure \
 	--with-vmversion=5.0 \
 	--with-src=nsspurstacksrc --disable-cogit \
-	--without-vm-display-fbdev --without-npsqueak --enable-fast-bitblt \
-	CC="gcc -march=armv6 -mfpu=vfp -mfloat-abi=hard" \
+	--without-vm-display-fbdev --without-npsqueak \
+	CC=gcc \
 	CXX=g++ \
 	CFLAGS="$OPT -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64" \
 	LIBS="-lpthread -luuid" \


### PR DESCRIPTION
 - Don't hardcode a Raspian configuration, which breaks ARMv7 Linux.
 - Disable fast bitblt as it is broken when assembled by ARMv7 gcc.
 - Don't link with libasound as Newspeak VM have no sound plugin.