### PR TITLE
update updateSCCSVersion script to run on checkout

### DIFF
--- a/scripts/updateSCCSVersions
+++ b/scripts/updateSCCSVersions
@@ -1,18 +1,31 @@
-#!/bin/sh
+#!/bin/bash
 # checkin script for Git that serves to cause
 # platforms/Cross/vm/sqSCCSVersion.h to be checked-in so that its version
 # info reflects that of the current check-in.
 if [ -d `dirname $0`/../.git ]; then
+    mkdir -p `dirname $0`/../.git/hooks/
     cp -f $0 `dirname $0`/../.git/hooks/post-commit
     cp -f $0 `dirname $0`/../.git/hooks/post-merge
+    cp -f $0 `dirname $0`/../.git/hooks/post-checkout
     cd `dirname $0`/..
 else
     cd `dirname $0`/../..
+    if [[ "$(basename $0)" == "post-checkout" ]]; then
+	prevHEAD=$1
+	newHEAD=$2
+	branchChange=$3
+	if [[ "$branchChange" == "0" ]] && [[ "$prevHEAD" == "$newHEAD" ]]; then
+	    # we did not switch branches and did not move to a new head (e.g. we
+	    # just did a checkout on a file
+	    exit 0
+	fi
+    fi
 fi
+
 git config --local include.path ../.gitconfig
-git stash
+git stash -q || true
 echo "//" >> platforms/Cross/vm/sqSCCSVersion.h
 echo "//" >> platforms/Cross/plugins/sqPluginsSCCSVersion.h
 git checkout HEAD -- platforms/Cross/vm/sqSCCSVersion.h
 git checkout HEAD -- platforms/Cross/plugins/sqPluginsSCCSVersion.h
-git stash pop || true
+git stash pop -q || true


### PR DESCRIPTION
This makes sure that we're updating the revision info also upon switching branches and during bisects and such.